### PR TITLE
dev-util/dub::dlang: requires NOCADD=1

### DIFF
--- a/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
+++ b/sys-config/ltoize/files/package.cflags/portage-bashrc-mv.conf
@@ -1,3 +1,4 @@
 # BEGIN: portage-bashrc-mv remove-la workarounds
 dev-util/colm NOLAFILEREMOVE=true # See issue 690 and https://bugs.gentoo.org/766210
+dev-util/dub::dlang NOCADD=1 # Required to avoid tainting LDFLAGS and breaking D compiler. See portage-bashrc-mv docs.
 # END: portage-bashrc-mv remove-la workarounds


### PR DESCRIPTION
dev-util/dub is from dlang overlay. It takes NOCADD=1 otherwise portage-bashrc-mv fills up LDFLAGS with CFLAGS that spill over to D compiler and break the build.

From portage-bashrc-mv docs:

NOCADD
	If this variable is false and some of CFLAGS, CXXFLAGS, or LDFLAGS
	contains -flto* then the CFLAGS and CXXFLAGS variables finally
	calculated will be added to the LDFLAGS.

[build.log](https://github.com/mccarverone/gentooLTO/files/9543493/build.log)
